### PR TITLE
fix: Use non-greedy matching to make URLs clickable

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -554,7 +554,7 @@ class Format {
             function($match) {
                 // Scan for things that look like URLs
                 return preg_replace_callback(
-                    '`(?<!>)(((f|ht)tp(s?)://|(?<!//)www\.)([-+~%/.\w]+)(?:[-?#+=&;%@.\w\[\]\/]*)?)'
+                    '`(?<!>)(((f|ht)tp(s?)://|(?<!//)www\.)([-+~%/.\w]+)(?:[-?#+=&;%@.\w\[\]\/]*)?)/U'
                    .'|(\b[_\.0-9a-z-]+@([0-9a-z][0-9a-z-]+\.)+[a-z]{2,63})`',
                     function ($match) {
                         if ($match[1]) {


### PR DESCRIPTION
If greedy, a URL of the form
   http://domain.com/www.i-am-a-subfolder/another-folder/
would be turned wrongly into 
   http://domain.com/http://www.i-am-a-subfolder/another-folder/
with 2 anchor tags: The first points to the correct URL, the second one points to a non-existing folder.